### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -16,6 +16,7 @@ import uuid
 from pathlib import Path
 from collections import deque
 import logging
+import traceback
 
 # Configure basic logging for this module
 logger = logging.getLogger(__name__)
@@ -905,8 +906,9 @@ def get_host_metrics():
             'updatedAt': datetime.utcnow().isoformat() + 'Z'
         })
     except Exception as e:
-        import traceback
-        return jsonify({'error': str(e), 'trace': traceback.format_exc()})
+        # Log detailed error and stack trace on the server, but do not expose them to the client
+        logger.error("Error while collecting host metrics: %s\n%s", e, traceback.format_exc())
+        return jsonify({'error': 'Internal server error'}), 500
 
 
 def format_uptime(seconds: int) -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/joshdev8/sentarr/security/code-scanning/8](https://github.com/joshdev8/sentarr/security/code-scanning/8)

In general, the fix is to avoid sending detailed exception information (message and stack trace) to the client, while still logging the details on the server. The client should receive a generic, non-sensitive error message and perhaps a simple status indicator, but not the stack trace or raw exception text.

Concretely for `api/server.py`, lines 907–909 should be changed so that:

- The exception is logged using the existing `logger` (configured at line 20).
- The stack trace is not included in the HTTP response.
- The response contains a generic error message and appropriate HTTP status code (e.g., 500).

Implementation details:

- Add an `import traceback` at the top of the file alongside other imports so we do not re-import it inside the function, and we can obtain the stack trace for logging.
- Modify the `except` block around lines 907–909 to:
  - Call `logger.error(...)` or `logger.exception(...)` to log the error and stack trace.
    - Using `logger.exception("...")` automatically logs the stack trace for the current exception, so `traceback.format_exc()` is not strictly required.
    - To stay close to the initial pattern and ensure detailed info is captured, we can either rely on `logger.exception` alone or include `traceback.format_exc()` explicitly in the log; both are safe because logs are server-side.
  - Return `jsonify({'error': 'Internal server error'})`, with a 500 status code using `Response` / Flask’s ability to return `(json, status_code)`.

No new external dependencies are needed; we only use Python’s standard library (`traceback`) and the already imported `logger` and Flask.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
